### PR TITLE
docs: OpenAPI ドキュメントの更新ルールを backend.md に追記

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -36,6 +36,17 @@ bundle exec rspec spec/requests/            # API リクエストテストのみ
 bundle exec rspec spec/path/to/file_spec.rb # 単一ファイル
 ```
 
+### OpenAPI ドキュメントの更新
+
+OpenAPI ドキュメント（`doc/openapi/`）は **`OPENAPI=1` を付けてテストを実行することで自動生成する**。手動編集は禁止。
+
+```bash
+docker-compose exec -e OPENAPI=1 web bundle exec rspec spec/requests/api/v1/admin/users_spec.rb
+```
+
+- ドキュメントにパラメータを追加したい場合は、そのパラメータを使う **動作確認テスト**（`openapi: false` なし）を用意することで反映する
+- **OpenAPI ドキュメント更新のためだけのテストを作ることは禁止**。テストは必ず動作の仕様を表すものとして書く
+
 ### カバレッジ要件
 
 - 新規コード: 80%以上（行カバレッジ）


### PR DESCRIPTION
## 概要

バックエンドの OpenAPI ドキュメント（`doc/openapi/`）更新ルールを `.claude/rules/backend.md` に追記します。

## 確認方法

`.claude/rules/backend.md` の「OpenAPI ドキュメントの更新」セクションを確認してください。

## 影響範囲

`.claude/rules/backend.md` のみ。実装コードへの影響なし。

## チェックリスト

- [x] 必要なドキュメントを作成した

## コメント

今回の実装作業（issue #252）で、OpenAPI ドキュメントを手動編集しようとするケースが発生したため、以下のルールを明文化しました。

- `OPENAPI=1 rspec` による自動生成が必須
- 手動編集禁止
- OpenAPI 更新のためだけのテスト作成禁止（動作確認テストで対応する）