### PR TITLE
chore: actions/checkout を v7 に更新し Node.js 20 非推奨警告を解消する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       front_sha: ${{ steps.detect.outputs.front_sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## 概要

issue #38 の PR #40 マージ後、`deploy.yml` の初回実行で Node.js 20 の非推奨警告が記録された。

```
[warning] Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4
```

現状は Node.js 24 で強制実行されて動作しているが、GitHub の[アナウンス](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)のとおりいずれ動かなくなる。`actions/checkout` を v4 から v7（最新: v7.0.1）に更新する。

back の `autodeploy.yml` は既に v7 を使っており警告が出ていないため、同じ水準に揃える形になる。

## 確認方法

1. 差分が `actions/checkout@v4` → `@v7` の1行のみであることを確認する
2. 使用しているオプション（`fetch-depth: 0` / `persist-credentials: false`）が v7 でも有効であることを確認する
   - back の `autodeploy.yml` が v7 で `ref` / `fetch-depth` / `persist-credentials` を使って正常動作している（[実行ログ](https://github.com/Alnoir-0011/algo_sangaku_back/actions/runs/30789236693)）
3. マージ後、次回のリリース PR マージ時に `deploy.yml` の run から警告が消えていることを確認する

**このワークフローは `push` to `main` でしか起動しないため、本 PR 上では実行できない。** 検証はマージ後の次回リリース時になる。ただし変更はアクションのバージョン指定のみで、`detect` のシェルロジックには一切触れていない。

## 影響範囲

- 親リポジトリの `.github/workflows/deploy.yml` のみ。`detect` の判定ロジック・`dispatch-back` / `dispatch-front` の挙動に変更はない
- `dispatch-*` ジョブは checkout を行わないため影響を受けない
- front 側にも同種の警告（`checkout` / `setup-node` / `upload-artifact` / `download-artifact` / `cache` の5種類）が出ているが、対象箇所が21箇所と多く artifact 系に breaking change の可能性があるため別 PR で対応する

## チェックリスト

- [x] YAML 構文検証（`ruby -ryaml`）
- [x] 使用オプションが v7 でサポートされていることを back の実行実績で確認
- [x] 最新バージョンを確認（`actions/checkout` は v7.0.1）
- [ ] マージ後、次回リリース時に警告が消えていることを確認（本 PR のスコープ外）

## コメント

- 3回目レビューで「`actions/checkout` のバージョン不揃い」を Minor 指摘として挙げた際、「front も v4 なので親リポの v4 は front と揃っており対応不要」と判断したが誤りだった。実態は「back だけが更新済みで、親と front が取り残されている」であり、実行時に警告が出ることで判明した

🤖 Generated with [Claude Code](https://claude.com/claude-code)
